### PR TITLE
Fix NoMethodError about Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+forked from https://github.com/amrfaissal/azuresearch-ruby-client :sparkles:
+
 # Ruby Client for Microsoft Azure Search
 
 [![Build Status](https://travis-ci.org/amrfaissal/azuresearch-ruby-client.svg?branch=master)](https://travis-ci.org/amrfaissal/azuresearch-ruby-client)

--- a/lib/azure_search/index_field.rb
+++ b/lib/azure_search/index_field.rb
@@ -2,6 +2,8 @@ module AzureSearch
 
   # Represents an Index field definition.
   class IndexField
+    include Utils
+
     # Valid EDM (Entity Data Model) data types.
     VALID_EDM_TYPES = [
       "Edm.String",

--- a/lib/azure_search/index_search_options.rb
+++ b/lib/azure_search/index_search_options.rb
@@ -4,6 +4,8 @@ module AzureSearch
 
   # Represents search options that will be sent along with a search request.
   class IndexSearchOptions
+    include Utils
+
     SPECIAL_PARAMS = %w(count filter orderby select top skip).freeze
 
     # Specifies whether to fetch the total count of results.

--- a/lib/azure_search/search_index_client.rb
+++ b/lib/azure_search/search_index_client.rb
@@ -12,7 +12,8 @@ module AzureSearch
 
   # Client to perform requests to an Azure Search service.
   class SearchIndexClient
-    include AzureSearch::Errors
+    include Errors
+    include Utils
 
     # @return [Symbol] The search service name.
     attr_accessor :service_name

--- a/lib/azure_search/utils.rb
+++ b/lib/azure_search/utils.rb
@@ -1,4 +1,4 @@
-module AzureSearch
+module AzureSearch module Utils
 
   # Checks if the supplied value is a Boolean.
   #
@@ -36,4 +36,4 @@ module AzureSearch
     }.join('&')
   end
 
-end
+end; end

--- a/spec/azure_search/utils_spec.rb
+++ b/spec/azure_search/utils_spec.rb
@@ -2,7 +2,7 @@ require 'azure_search/utils'
 
 describe AzureSearch do
   let(:dummy_class) {
-    Class.new { extend AzureSearch }
+    Class.new { extend AzureSearch::Utils }
   }
 
   it 'checks if supplied value is a boolean' do


### PR DESCRIPTION
Fixed NoMethodError bellow

```
vendor/bundle/ruby/2.4.0/gems/azure_search-0.1.0/lib/azure_search/index_field.rb:39:in
`searchable': undefined method `is_bool?'
for #<AzureSearch::IndexField:0x00007fa03a894608> (NoMethodError)
```

- moved methods of utils.rb to module AzureSearch::Utils
- added include method to class using the util methods